### PR TITLE
Adds a channel for startup notification for the flowify-server

### DIFF
--- a/main.go
+++ b/main.go
@@ -166,7 +166,7 @@ func main() {
 		panic("Cannot create a Flowify server object")
 	}
 
-	server.Run(ctx)
+	server.Run(ctx, nil)
 
 	// Create a deadline to wait for.
 	ctx, cancel = context.WithTimeout(context.Background(), maxWait)


### PR DESCRIPTION
It's optional to use. Primarily used in tests, to avoid clunky timing-retry-constructs