### PR TITLE
Fix SIGTERM signal trap

### DIFF
--- a/dev/cluster_runner.sh
+++ b/dev/cluster_runner.sh
@@ -57,4 +57,7 @@ then
   kubectl rollout status deployments -n argo
 fi
 
-sleep infinity
+while true
+do
+	sleep 1
+done


### PR DESCRIPTION
`sleep infinity` prevents catching the `SIGTERM` signal from docker, so after few second docker sends `SIGKILL` signal which cannot be handled